### PR TITLE
Updated user display name in Chats

### DIFF
--- a/frontend/src/components/AddUsersSheet.js
+++ b/frontend/src/components/AddUsersSheet.js
@@ -38,7 +38,7 @@ const AddUsersSheet = (props) => {
       const usersFromFB = querySnapshot.docs.map((doc) => ({
         id: doc.id,
         icon: doc.data().icon,
-        name: doc.data().name,
+        name: doc.data().studentname,
       }));
       setUserList(usersFromFB);
     });

--- a/frontend/src/screens/ChatsListScreen.js
+++ b/frontend/src/screens/ChatsListScreen.js
@@ -93,7 +93,7 @@ const ChatsListScreen = ({ navigation }) => {
 
             return {
               id: document.id,
-              name: docSnap.data().name,
+              name: docSnap.data().studentname,
               icon: docSnap.data().icon,
               latestMsg: {
                 text: document.data().latestMsg.text,


### PR DESCRIPTION
**Updates:** 
Instead of displaying the split(email name), I updated it to Student Name which displays the full name of the current user. [See Attached Screenshots]. Let me know your thoughts on this, thanks! 😀

![Simulator Screen Shot - iPhone 11 - 2022-12-06 at 16 07 57](https://user-images.githubusercontent.com/38415406/206023174-710eaf66-6d13-403f-bd33-b63c91b77beb.png)
![Simulator Screen Shot - iPhone 11 - 2022-12-06 at 16 08 04](https://user-images.githubusercontent.com/38415406/206023175-f1c5a1a9-683c-4081-a743-49f1309cc72f.png)
